### PR TITLE
Update Splunk template 

### DIFF
--- a/templates/splunk-enterprise.template
+++ b/templates/splunk-enterprise.template
@@ -808,6 +808,7 @@
                                 },
                                 "\n",
                                 "mkdir -p $SPLUNK_HOME/etc/licenses/enterprise\n",
+                                "chown $SPLUNK_USER:$SPLUNK_USER $SPLUNK_HOME/etc/licenses/enterprise\n",
                                 "mv /etc/splunk/splunk.license $SPLUNK_HOME/etc/licenses/enterprise/\n",
                                 "# Increase splunkweb connection timeout with splunkd\n",
                                 "printf '\n%s\n%s = %s\n' [settings] splunkdConnectionTimeout 300  >> $SPLUNK_HOME/etc/system/local/web.conf\n",

--- a/templates/splunk-enterprise.template
+++ b/templates/splunk-enterprise.template
@@ -1550,7 +1550,7 @@
                                     "Ref": "SplunkAdminPassword"
                                 },
                                 "\n",
-                                "service splunk restart\n",
+
                                 "/opt/aws/bin/cfn-signal -e $? --stack ",
                                 {
                                     "Ref": "AWS::StackName"

--- a/templates/splunk-enterprise.template
+++ b/templates/splunk-enterprise.template
@@ -1576,24 +1576,7 @@
             "Type": "AWS::IAM::User",
             "Condition": "ConfigureLicense",
             "Properties": {
-                "Path": "/",
-                "Policies": [
-                    {
-                        "PolicyName": "root",
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "cloudformation:DescribeStackResource",
-                                        "s3:GetObject"
-                                    ],
-                                    "Resource": "*"
-                                }
-                            ]
-                        }
-                    }
-                ]
+                "Path": "/"
             }
         },
         "CfnKeys": {


### PR DESCRIPTION
- Remove redundant and permissive user inline policy
- Remove restart after captain bootstrap which can mess up with initial conf replication

cc @billbartlett 